### PR TITLE
Show build output while still in progress.

### DIFF
--- a/sideloader/tasks.py
+++ b/sideloader/tasks.py
@@ -30,7 +30,7 @@ def build(build, giturl, branch):
         build.log += line
         build.save()
 
-    p.communicate()
+    builder.communicate()
 
     if builder.returncode != 0:
         build.state = 2


### PR DESCRIPTION
It looks like currently stuff is buffered which makes it difficult to see what's going on (especially with a build that takes a long time to complete)
