### PR TITLE
Fail broken builds

### DIFF
--- a/bin/build_package
+++ b/bin/build_package
@@ -141,6 +141,9 @@ class Sideloader:
             open(os.path.join(self.workspace, self.repo, self.deploy_file))
         )
 
+        self.allow_broken_build = self.deploy_yam.get(
+            'allow_broken_build', False)
+
         # Paths for post-install time
         venv_prefix = self.deploy_yam.get('virtualenv_prefix')
         if venv_prefix is not None:
@@ -214,6 +217,8 @@ class Sideloader:
             except Exception as err:
                 print "Warning: Could not copy %s to package: %s %s" % (
                     d, type(err), err)
+                if not self.allow_broken_build:
+                    sys.exit(1)
 
         # Create nginx configs
         for conf in self.deploy_yam.get('nginx', []):
@@ -342,7 +347,9 @@ fi\n""" % (os.path.join(self.install_venv, 'bin/python'), self.install_venv))
             )
 
         os.system('chmod a+x %s' % buildscript)
-        os.system(buildscript)
+        if os.system(buildscript):
+            if not self.allow_broken_build:
+                sys.exit(1)
 
         self.createPackage()
 

--- a/bin/build_package
+++ b/bin/build_package
@@ -60,6 +60,10 @@ class Sideloader:
         else:
             ws = self.repo
 
+        # We set this to `False` here so we can use `self.fail_build()` before
+        # we've read the deploy config.
+        self.allow_broken_build = False
+
         # Rip the github url apart
         chunks = self.githuburl.split(':')[1].split('/')
         self.repo = chunks[-1][:-4]
@@ -217,8 +221,7 @@ class Sideloader:
             except Exception as err:
                 print "Warning: Could not copy %s to package: %s %s" % (
                     d, type(err), err)
-                if not self.allow_broken_build:
-                    sys.exit(1)
+                self.fail_build("Error copying files to package")
 
         # Create nginx configs
         for conf in self.deploy_yam.get('nginx', []):
@@ -347,11 +350,21 @@ fi\n""" % (os.path.join(self.install_venv, 'bin/python'), self.install_venv))
             )
 
         os.system('chmod a+x %s' % buildscript)
-        if os.system(buildscript):
-            if not self.allow_broken_build:
-                sys.exit(1)
+        exit_status = os.system(buildscript)
+        # The high byte of the exit status is the process exit code.
+        exit_code = exit_status >> 8
+        if exit_code != 0:
+            self.fail_build("Build script exited with code %s" % exit_code)
 
         self.createPackage()
+
+    def fail_build(self, reason, code=1):
+        if self.allow_broken_build:
+            self.log("Build failure overridden: %s" % reason)
+        else:
+            self.log("Build failed: %s" % reason)
+            sys.exit(code)
+
 
 sideloader = Sideloader()
 sideloader.buildProject()

--- a/tests/test_build_package.py
+++ b/tests/test_build_package.py
@@ -199,6 +199,11 @@ def test_broken_build_succeeds(builder):
     assert build_copyfail.read() == "copy fail\n"
     assert package_copyfail.check(exists=False)
 
+    assert build_result.contains_regex(
+        r"\[.*\] Build failure overridden: Build script exited with code 1$")
+    assert build_result.contains_regex(
+        r"\[.*\] Build failure overridden: Error copying files to package$")
+
 
 def test_build_with_bad_file_fails(builder):
     """
@@ -221,6 +226,8 @@ def test_build_with_bad_file_fails(builder):
         "<type 'exceptions.OSError'> [Errno 20] Not a directory:",
         "'%s'" % workspace_dir.join("build", "copyfail.txt"))
     assert build_result.contains_line(copy_warning)
+    assert build_result.contains_regex(
+        r"\[.*\] Build failed: Error copying files to package$")
 
 
 def test_build_with_script_error_fails(builder):
@@ -236,6 +243,8 @@ def test_build_with_script_error_fails(builder):
     build_result = builder.run_build("--id=id0", "file://%s" % repo_dir)
     assert build_result.code == 1
     assert build_result.contains_line("hello from builder")
+    assert build_result.contains_regex(
+        r"\[.*\] Build failed: Build script exited with code 1$")
 
 
 def test_venv_path_config(builder):


### PR DESCRIPTION
Currently, the builder swallows a bunch of exceptions and claims success when the build might actually be broken. (This has bitten me more than once.)

Builds should fail if the build script returns a nonzero exit code or if various other parts of the build process fail. To allow existing "broken" builds that still produce usable outputs to continue to work, we should add a config option (possibly one that can be overridden at the system level) to let people tell sideloader that they're happy with broken builds.