### PR TITLE
Builds for a missing branch should fail

### DIFF
--- a/bin/build_package
+++ b/bin/build_package
@@ -146,8 +146,9 @@ class Sideloader:
 
         # Checkout the desired branch
         os.chdir(os.path.join(self.workspace, self.repo))
-        if os.system('git checkout %s' % self.branch) != 0:
-            self.fail_build("Can't switch to branch")
+        self.call_or_fail(
+            'git checkout %s' % self.branch,
+            "Can't switch to branch")
 
         try:
             self.deploy_yam = yaml.load(
@@ -379,12 +380,9 @@ fi\n""" % (os.path.join(self.install_venv, 'bin/python'), self.install_venv))
 
         os.chdir(repo)
 
-        exit_status = os.system('/usr/bin/docker build --pull -t %s .' % self.name)
-
-        exit_code = exit_status >> 8
-
-        if exit_code != 0:
-            self.fail_build("Build script exited with code %s" % exit_code)
+        self.call_or_fail(
+            '/usr/bin/docker build --pull -t %s .' % self.name,
+            "Build script exited with code {exit_code}")
 
     def buildProject(self):
         self.createWorkspace()
@@ -405,11 +403,8 @@ fi\n""" % (os.path.join(self.install_venv, 'bin/python'), self.install_venv))
                 )
 
             os.system('chmod a+x %s' % buildscript)
-            exit_status = os.system(buildscript)
-            # The high byte of the exit status is the process exit code.
-            exit_code = exit_status >> 8
-            if exit_code != 0:
-                self.fail_build("Build script exited with code %s" % exit_code)
+            self.call_or_fail(
+                buildscript, "Build script exited with code {exit_code}")
 
         self.createPackage()
 
@@ -420,6 +415,12 @@ fi\n""" % (os.path.join(self.install_venv, 'bin/python'), self.install_venv))
             self.log("Build failed: %s" % reason)
             sys.exit(code)
 
+    def call_or_fail(self, command, failmsg):
+        exit_status = os.system(command)
+        # The high byte of the exit status is the process exit code.
+        exit_code = exit_status >> 8
+        if exit_code != 0:
+            self.fail_build(failmsg.format(exit_code=exit_code))
 
 sideloader = Sideloader()
 sideloader.buildProject()

--- a/bin/build_package
+++ b/bin/build_package
@@ -146,7 +146,8 @@ class Sideloader:
 
         # Checkout the desired branch
         os.chdir(os.path.join(self.workspace, self.repo))
-        os.system('git checkout %s' % self.branch)
+        if os.system('git checkout %s' % self.branch) != 0:
+            self.fail_build("Can't switch to branch")
 
         try:
             self.deploy_yam = yaml.load(

--- a/sideloader/tests/test_tasks.py
+++ b/sideloader/tests/test_tasks.py
@@ -133,6 +133,25 @@ class TestTasks(unittest.TestCase):
         ])
 
     @defer.inlineCallbacks
+    def test_build_missing_branch(self):
+        """
+        If the branch we want to build doesn't exist, the build fails.
+        """
+        repo = self.mkrepo('sideloader', add_scripts=False)
+        yield self.setup_db(dictmerge(
+            PROJECT_SIDELOADER, github_url=repo.url, branch='stormdamage'))
+        notifications = self.patch_notifications()
+        yield self.plug.call_build({'build_id': 1})
+
+        build = yield self._wait_for_build(1)
+        self.assertEqual(build['state'], 2)
+        self.assertEqual(build['build_file'], '')
+        self.assert_notifications(notifications, [
+            "projects/build/view/1|#1> started for branch stormdamage",
+            "projects/build/view/1|#1> failed",
+        ])
+
+    @defer.inlineCallbacks
     def test_build_missing_scripts(self):
         """
         If the build and postinst scripts are missing, the build fails.

--- a/tests/test_build_package.py
+++ b/tests/test_build_package.py
@@ -205,6 +205,27 @@ def test_broken_build_succeeds(builder):
         r"\[.*\] Build failure overridden: Error copying files to package$")
 
 
+def test_build_with_bad_branch_fails(builder):
+    """
+    A build for a branch that doesn't exist fails.
+    """
+    builder.write_sideloader_config()
+    repo_dir = builder.create_repo("org", "project")
+    builder.create_branch(repo_dir, "master", files={
+        ".deploy.yaml": yaml.dump({"buildscript": "scripts/build.sh"}),
+        "scripts/build.sh": "echo 'hello from builder'",
+    })
+    build_result = builder.run_build(
+        "--id=id0", "file://%s" % repo_dir, "--branch", "stormdamage")
+    assert build_result.code == 1
+
+    assert build_result.contains_line(
+        "error: pathspec 'stormdamage' did not match"
+        " any file(s) known to git.")
+    assert build_result.contains_regex(
+        r"\[.*\] Build failed: Can't switch to branch$")
+
+
 def test_build_with_bad_file_fails(builder):
     """
     A build with files that can't be copied into the package fails.


### PR DESCRIPTION
Instead, the default branch is built. (I discovered this in #83.)