### PR TITLE
Switch to python-social-auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ before_script:
   - cp config.yaml.example config.yaml
   - gem install fpm --no-ri --no-rdoc
   - psql -c 'create database sideloader;' -U postgres
-  # Hacky thing to prevent social auth stuff from breaking the db setup.
-  - python manage.py migrate auth || true
   - python manage.py migrate
   - python manage.py createsuperuser --noinput --username=root --email=root@example.com
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ before_script:
   - python manage.py createsuperuser --noinput --username=root --email=root@example.com
 
 script:
-  - py.test sideloader/ tests/
+  - py.test sideloader/ tests/ --ds=skeleton.settings

--- a/requirements-dev.pip
+++ b/requirements-dev.pip
@@ -1,2 +1,3 @@
 pytest
 pytest-trialtemp
+pytest-django

--- a/requirements.pip
+++ b/requirements.pip
@@ -7,7 +7,7 @@ django-nose
 django-haystack
 psycopg2
 redis
-django-social-auth
+python-social-auth
 pep8
 pyflakes
 pyyaml

--- a/sideloader/templates/login.html
+++ b/sideloader/templates/login.html
@@ -35,8 +35,8 @@
 
         <input type="hidden" name="next" value="{{ next }}" />
         <br/>
-        <a href="{% url 'socialauth_begin' backend='github' %}" class="btn">Login with GitHub</a>
-        <a href="{% url 'socialauth_begin' backend='google-oauth2' %}" class="btn">Login with Google</a>
+        <a href="{% url 'social:begin' backend='github' %}" class="btn">Login with GitHub</a>
+        <a href="{% url 'social:begin' backend='google-oauth2' %}" class="btn">Login with Google</a>
         </form>
 
     </div>

--- a/sideloader/tests/test_views.py
+++ b/sideloader/tests/test_views.py
@@ -1,0 +1,24 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+
+class TestIndex(TestCase):
+    def test_auth_required(self):
+        """
+        We can't look at things if we're not logged in.
+        """
+        resp = self.client.get("/")
+        self.assertRedirects(resp, "/accounts/login/?next=/")
+
+    def test_logged_in(self):
+        """
+        We can look at things if we're logged in.
+        """
+        User.objects.create_user("me", "me@example.com", "p455w0rd")
+        self.client.login(username="me", password="p455w0rd")
+        resp = self.client.get("/")
+        self.assertEqual(resp.status_code, 200)
+        # We have no data, so all these will be empty.
+        self.assertQuerysetEqual(resp.context["builds"], [])
+        self.assertQuerysetEqual(resp.context["last_builds"], [])
+        self.assertQuerysetEqual(resp.context["projects"], [])

--- a/skeleton/settings.py
+++ b/skeleton/settings.py
@@ -137,7 +137,7 @@ INSTALLED_APPS = (
     # 'django.contrib.admindocs',
     'gunicorn',
     'raven.contrib.django.raven_compat',
-    'social_auth',
+    'social.apps.django_app.default',
     'crispy_forms',
     'sideloader',
 )

--- a/skeleton/urls.py
+++ b/skeleton/urls.py
@@ -63,7 +63,7 @@ urlpatterns = patterns('',
     url(r'^accounts/logout/$', 'django.contrib.auth.views.logout', {'next_page': '/'}, name='auth_logout'),
     url(r'^accounts/profile/$', 'sideloader.views.accounts_profile', name='accounts_profile'),
 
-    url(r'', include('social_auth.urls')),
+    url(r'', include('social.apps.django_app.urls', namespace='social')),
 
     # Uncomment the next line to enable the admin:
     url(r'^admin/', include(admin.site.urls)),


### PR DESCRIPTION
Because django-social-auth is abandoned and screws up database migration.