### PR TITLE
Release task sends local timestamp as UTC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_script:
   - git config --global user.name "Testy Testerson"
   - cp config.yaml.example config.yaml
   - gem install fpm --no-ri --no-rdoc
+  - export PATH="$(gem env gemdir)/bin:$PATH"
   - psql -c 'create database sideloader;' -U postgres
   - python manage.py migrate
   - python manage.py createsuperuser --noinput --username=root --email=root@example.com

--- a/sideloader/tasks.py
+++ b/sideloader/tasks.py
@@ -161,7 +161,7 @@ class Plugin(RhumbaPlugin):
             'build_id': build_id,
             'waiting': True,
             'scheduled': scheduled,
-            'release_date': datetime.datetime.now(),
+            'release_date': datetime.datetime.utcnow(),
             'lock': False
         })
 

--- a/sideloader/tests/test_tasks.py
+++ b/sideloader/tests/test_tasks.py
@@ -294,15 +294,14 @@ class TestTasks(unittest.TestCase):
         self.assertEqual(release['scheduled'], None)
         self.assertEqual(release['waiting'], True)
 
-    @pytest.mark.xfail
     @pytest.mark.usefixtures('env_tz')
     @defer.inlineCallbacks
     def test_build_and_release_timezone(self):
         """
         When we build a release, we send the timestamp in UTC.
 
-        This test is only useful if it's run in an environment with a timezone
-        that isn't equivalent to UTC.
+        The twisted database stuff assumes timezones are in UTC and sends them
+        to postgres with an explicit zero offset.
         """
         repo = self.mkrepo('sideloader')
         yield self.setup_db(

--- a/sideloader/tests/test_tasks.py
+++ b/sideloader/tests/test_tasks.py
@@ -1,5 +1,7 @@
+from datetime import datetime
 import os
 
+import pytest
 from twisted.trial import unittest
 from twisted.internet import defer, reactor, task
 from twisted.web import resource, server
@@ -10,6 +12,11 @@ from sideloader.tests.fake_data import (
     RELEASESTREAM_QA, RELEASESTREAM_PROD, PROJECT_SIDELOADER,
     RELEASEFLOW_QA, RELEASEFLOW_PROD, BUILD_1, WEBHOOK_QA_1, WEBHOOK_QA_2)
 from sideloader.tests.utils import dictmerge
+
+
+@pytest.fixture
+def env_tz(monkeypatch):
+    monkeypatch.setenv('TZ', 'test-5')
 
 
 def id_sorted(rows):
@@ -127,6 +134,12 @@ class TestTasks(unittest.TestCase):
                 len(end_texts), notifications))
         for notification, end_text in zip(notifications, end_texts):
             self.assert_notification(notification, end_text)
+
+    def assert_time_between(self, start, end, timestamp, name='timestamp'):
+        self.assertTrue(
+            start <= timestamp <= end,
+            "Expected %s between %r and %r, got %r" % (
+                name, start, end, timestamp))
 
     @defer.inlineCallbacks
     def setup_db(self, project_def, build_number=1, flow_defs=()):
@@ -280,6 +293,38 @@ class TestTasks(unittest.TestCase):
         self.assertEqual(release['flow_id'], RELEASEFLOW_PROD['id'])
         self.assertEqual(release['scheduled'], None)
         self.assertEqual(release['waiting'], True)
+
+    @pytest.mark.xfail
+    @pytest.mark.usefixtures('env_tz')
+    @defer.inlineCallbacks
+    def test_build_and_release_timezone(self):
+        """
+        When we build a release, we send the timestamp in UTC.
+
+        This test is only useful if it's run in an environment with a timezone
+        that isn't equivalent to UTC.
+        """
+        repo = self.mkrepo('sideloader')
+        yield self.setup_db(
+            dictmerge(PROJECT_SIDELOADER, github_url=repo.url),
+            flow_defs=[RELEASEFLOW_PROD])
+
+        start = datetime.utcnow()
+
+        yield self.plug.call_build({'build_id': 1})
+        build = yield self._wait_for_build(1)
+        self.assertEqual(build['state'], 1)
+        # FIXME: We dig directly into our fake db here, because we haven't
+        #        implemented FakeDB.getReleases() yet.
+        self.assertEqual(self.plug.db._release, {})
+        yield self.plug.call_release(
+            {'build_id': 1, 'flow_id': RELEASEFLOW_PROD['id']})
+        [release] = yield self.plug.db._release.values()
+
+        end = datetime.utcnow()
+
+        self.assert_time_between(
+            start, end, release['release_date'], 'release_date')
 
     @defer.inlineCallbacks
     def test_build_and_autorelease(self):


### PR DESCRIPTION
If the local timezone isn't UTC, this results in an offset between build and release timestamps.
